### PR TITLE
Shards are now not starting all at once

### DIFF
--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -350,9 +350,18 @@ public class Main {
         return translationManager;
     }
 
+    /**
+     * Start shard by id
+     *
+     * @param shardId shard id
+     */
     public static void startShard(int shardId) {
-        if (shardId > shardManager.getShardsTotal()) return;
+        if (shardId >= shardManager.getShardsTotal()) {
+            System.out.println("[WARNING|SHARD] Cannot start Shard #" + shardId + "! Only " + shardManager.getShardsTotal() + " total shards registered.");
+            return;
+        }
 
+        System.out.println("[INFO|SHARD] Shard #" + shardId + " is starting now...");
         shardManager.start(shardId);
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -104,8 +104,9 @@ public class Main {
 
                 .setStatus(OnlineStatus.ONLINE);
 
-        shardManager = defaultShardManagerBuilder.build();
+        shardManager = defaultShardManagerBuilder.build(false);
 
+        shardManager.start(0);
 
         new Timer().schedule(new CloseTimedPolls(), 5 * 60 * 1000, 3 * 1000);
 
@@ -347,5 +348,11 @@ public class Main {
      */
     public static TranslationManager getTranslationManager() {
         return translationManager;
+    }
+
+    public static void startShard(int shardId) {
+        if (shardId > shardManager.getShardsTotal()) return;
+
+        shardManager.start(shardId);
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
@@ -19,6 +19,7 @@
 package de.fbrettnich.easypoll.listener;
 
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.core.Main;
 import de.fbrettnich.easypoll.timertasks.GameStatus;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -32,5 +33,7 @@ public class ReadyListener extends ListenerAdapter {
         Constants.BOT_ID = event.getJDA().getSelfUser().getId();
         new Timer().schedule(new GameStatus(event.getJDA()), 1000, 2*60*1000);
         System.out.println("[INFO|READY] EasyPoll (Shard #" + event.getJDA().getShardInfo().getShardId() + ") is running on " + event.getJDA().getGuilds().size() + " servers.");
+
+        Main.startShard(event.getJDA().getShardInfo().getShardId() + 1);
     }
 }


### PR DESCRIPTION


### Changes

New Feature: Shards will now be started after one another

### Description

The DefaultShardManager will now be build with login set to false. This allows for all shards to be started after one another reducing cpu-load during startup. This WILL however result in a longer startup time for the shards with a higher id.