### PR TITLE
Fixed #29

### DIFF
--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -104,8 +104,9 @@ public class Main {
 
                 .setStatus(OnlineStatus.ONLINE);
 
-        shardManager = defaultShardManagerBuilder.build();
+        shardManager = defaultShardManagerBuilder.build(false);
 
+        shardManager.start(0);
 
         new Timer().schedule(new CloseTimedPolls(), 5 * 60 * 1000, 3 * 1000);
 
@@ -347,5 +348,20 @@ public class Main {
      */
     public static TranslationManager getTranslationManager() {
         return translationManager;
+    }
+
+    /**
+     * Start shard by id
+     *
+     * @param shardId shard id
+     */
+    public static void startShard(int shardId) {
+        if (shardId >= shardManager.getShardsTotal()) {
+            System.out.println("[WARNING|SHARD] Cannot start Shard #" + shardId + "! Only " + shardManager.getShardsTotal() + " total shards registered.");
+            return;
+        }
+
+        System.out.println("[INFO|SHARD] Shard #" + shardId + " is starting now...");
+        shardManager.start(shardId);
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -373,7 +373,7 @@ public class Main {
         }
 
         //Check if previous Shard crashed
-        if (!shardManager.getShardById(shardId - 1).getStatus().isInit()) {
+        if (shardManager.getShardById(shardId - 1) == null || !shardManager.getShardById(shardId - 1).getStatus().isInit()) {
             System.out.println("[WARNING|SHARD] Found Shard #" + (shardId - 1) + " in illegal state, Shard #" + shardId + " will not start.");
             return;
         }

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -114,7 +114,7 @@ public class Main {
             shardQueueField.setAccessible(true);
             ((ConcurrentLinkedQueue) shardQueueField.get(shardManager)).clear();
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            e.printStackTrace();
+            Sentry.captureException(e);
         }
 
         shardManager.start(0);

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -104,9 +104,8 @@ public class Main {
 
                 .setStatus(OnlineStatus.ONLINE);
 
-        shardManager = defaultShardManagerBuilder.build(false);
+        shardManager = defaultShardManagerBuilder.build();
 
-        shardManager.start(0);
 
         new Timer().schedule(new CloseTimedPolls(), 5 * 60 * 1000, 3 * 1000);
 
@@ -348,20 +347,5 @@ public class Main {
      */
     public static TranslationManager getTranslationManager() {
         return translationManager;
-    }
-
-    /**
-     * Start shard by id
-     *
-     * @param shardId shard id
-     */
-    public static void startShard(int shardId) {
-        if (shardId >= shardManager.getShardsTotal()) {
-            System.out.println("[WARNING|SHARD] Cannot start Shard #" + shardId + "! Only " + shardManager.getShardsTotal() + " total shards registered.");
-            return;
-        }
-
-        System.out.println("[INFO|SHARD] Shard #" + shardId + " is starting now...");
-        shardManager.start(shardId);
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/core/Main.java
+++ b/src/main/java/de/fbrettnich/easypoll/core/Main.java
@@ -104,8 +104,9 @@ public class Main {
 
                 .setStatus(OnlineStatus.ONLINE);
 
-        shardManager = defaultShardManagerBuilder.build();
+        shardManager = defaultShardManagerBuilder.build(false);
 
+        shardManager.start(0);
 
         new Timer().schedule(new CloseTimedPolls(), 5 * 60 * 1000, 3 * 1000);
 
@@ -347,5 +348,31 @@ public class Main {
      */
     public static TranslationManager getTranslationManager() {
         return translationManager;
+    }
+
+    /**
+     * Start shard by id
+     *
+     * @param shardId shard id
+     */
+    public static void startShard(int shardId) throws InterruptedException {
+        if (shardId >= shardManager.getShardsTotal()) {
+            System.out.println("[WARNING|SHARD] Cannot start Shard #" + shardId + "! Only " + shardManager.getShardsTotal() + " total shards registered.");
+            return;
+        }
+
+        if (shardManager.getShardById(shardId).getStatus().equals(JDA.Status.CONNECTED)) {
+            System.out.println("[WARNING|SHARD] Tried to start Shard #" + shardId + " but Shard #" + shardId + " is already running.");
+            return;
+        }
+
+        if (!shardManager.getShardById(shardId - 1).getStatus().equals(JDA.Status.CONNECTED)) {
+            System.out.println("[WARNING|SHARD] Delaying start of Shard #" + shardId + "! Shard #" + (shardId - 1) + " is still starting.");
+        }
+
+        shardManager.getShardById(shardId - 1).awaitReady();
+
+        System.out.println("[INFO|SHARD] Shard #" + shardId + " is starting now...");
+        shardManager.start(shardId);
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
@@ -19,7 +19,9 @@
 package de.fbrettnich.easypoll.listener;
 
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.core.Main;
 import de.fbrettnich.easypoll.timertasks.GameStatus;
+import io.sentry.Sentry;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
@@ -32,5 +34,11 @@ public class ReadyListener extends ListenerAdapter {
         Constants.BOT_ID = event.getJDA().getSelfUser().getId();
         new Timer().schedule(new GameStatus(event.getJDA()), 1000, 2*60*1000);
         System.out.println("[INFO|READY] EasyPoll (Shard #" + event.getJDA().getShardInfo().getShardId() + ") is running on " + event.getJDA().getGuilds().size() + " servers.");
+
+        try {
+            Main.startShard(event.getJDA().getShardInfo().getShardId() + 1);
+        } catch (InterruptedException e) {
+            Sentry.captureException(e);
+        }
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
@@ -19,6 +19,7 @@
 package de.fbrettnich.easypoll.listener;
 
 import de.fbrettnich.easypoll.core.Constants;
+import de.fbrettnich.easypoll.core.Main;
 import de.fbrettnich.easypoll.timertasks.GameStatus;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -32,5 +33,7 @@ public class ReadyListener extends ListenerAdapter {
         Constants.BOT_ID = event.getJDA().getSelfUser().getId();
         new Timer().schedule(new GameStatus(event.getJDA()), 1000, 2*60*1000);
         System.out.println("[INFO|READY] EasyPoll (Shard #" + event.getJDA().getShardInfo().getShardId() + ") is running on " + event.getJDA().getGuilds().size() + " servers.");
+
+        Main.startShard(event.getJDA().getShardInfo().getShardId() + 1);
     }
 }

--- a/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
+++ b/src/main/java/de/fbrettnich/easypoll/listener/ReadyListener.java
@@ -19,7 +19,6 @@
 package de.fbrettnich.easypoll.listener;
 
 import de.fbrettnich.easypoll.core.Constants;
-import de.fbrettnich.easypoll.core.Main;
 import de.fbrettnich.easypoll.timertasks.GameStatus;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -33,7 +32,5 @@ public class ReadyListener extends ListenerAdapter {
         Constants.BOT_ID = event.getJDA().getSelfUser().getId();
         new Timer().schedule(new GameStatus(event.getJDA()), 1000, 2*60*1000);
         System.out.println("[INFO|READY] EasyPoll (Shard #" + event.getJDA().getShardInfo().getShardId() + ") is running on " + event.getJDA().getGuilds().size() + " servers.");
-
-        Main.startShard(event.getJDA().getShardInfo().getShardId() + 1);
     }
 }


### PR DESCRIPTION
### Changes

Shards are now waiting for the previous one to fully connect before connecting themselves. Shards will also load after one another reducing the cpu-load on startup.

### Description

Shardmanager is build with login set to false and only shard 0 is started immediately, other shards are then startet once the previous shard is fully operational.
